### PR TITLE
Remove invalid Additional_repositories

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,3 @@ RoxygenNote: 5.0.1
 NeedsCompilation: no
 Packaged: 2016-08-07 13:30:00 UTC; Davies
 VignetteBuilder: knitr
-Additional_repositories: http://zacdav.github.io/drat/


### PR DESCRIPTION
http://zacdav.github.io/drat/ currently 404's, causing errors when
trying to install blkbox using devtools, which uses
Additional_repositories if they are available.